### PR TITLE
feat: allow passing of custom URLs

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -6,10 +6,12 @@ var OAuth2Strategy = require('passport-oauth2')
  * https://orcid.org/content/register-client-application-0
  *
  * Options:
- *   - `sandbox`       whether to use the ORCID sandbox API (for non-production environments)
- *   - `clientID`      your ORCID application's client id
- *   - `clientSecret`  your ORCID application's client secret
- *   - `callbackURL`   URL to which ORCID will redirect the user after granting authorization
+ *   - `sandbox`           whether to use the ORCID sandbox API (for non-production environments)
+ *   - `clientID`          your ORCID application's client id
+ *   - `clientSecret`      your ORCID application's client secret
+ *   - `callbackURL`       URL to which ORCID will redirect the user after granting authorization
+ *   - `authorizationURL`  optional override for mocking service 
+ *   - `tokenURL`          optional override for mocking service
  *
  * Example:
  *
@@ -36,19 +38,21 @@ var OAuth2Strategy = require('passport-oauth2')
  * @access public
  */
 function Strategy (options, verify) {
-  options.scope = options.scope || '/authenticate'
-
-  if (options.sandbox) {
-    options.authorizationURL = 'https://sandbox.orcid.org/oauth/authorize'
-    options.tokenURL = 'https://sandbox.orcid.org/oauth/token'
-  } else {
-    options.authorizationURL = 'https://orcid.org/oauth/authorize'
-    options.tokenURL = 'https://orcid.org/oauth/token'
-  }
-
+  const orcidHostname = options.sandbox ? 'sandbox.orcid.org' : 'orcid.org'
   delete options.sandbox
 
-  OAuth2Strategy.call(this, options, verify)
+  const defaults = {
+    scope: '/authenticate',
+    authorizationURL: `https://${orcidHostname}/oauth/authorize`,
+    tokenURL: `https://${orcidHostname}/oauth/token`,
+  }
+
+  const mergedConfig = {
+    ...defaults,
+    ...options
+  }
+
+  OAuth2Strategy.call(this, mergedConfig, verify)
   this.name = 'orcid'
 }
 


### PR DESCRIPTION
We would like to mock orcid with our own service.